### PR TITLE
noted required setting for accessing public shares over WebDAV

### DIFF
--- a/modules/user_manual/pages/files/access_webdav.adoc
+++ b/modules/user_manual/pages/files/access_webdav.adoc
@@ -413,6 +413,10 @@ https://example.com/owncloud/public.php/webdav
 in a WebDAV client, use the share token as username and the (optional)
 share password as password.
 
+NOTE: `Settings → Administration → Sharing → Allow users on this server
+to send shares to other servers` needs to be enabled in order to make
+this feature work.
+
 [[known-problems]]
 Known Problems
 --------------


### PR DESCRIPTION
Recently, we found that the setting "Allow users on this server to send shares to other servers" is required in order to access public shares over WebDAV.
If this setting is not enabled, "HTTP Access Denied" is returned (which is correct, but) what makes it difficult to find out how to enable this feature.
Hence, we should note this in the docs.